### PR TITLE
Adding relative, styling, typescript

### DIFF
--- a/src/RightButton.js
+++ b/src/RightButton.js
@@ -84,7 +84,7 @@ const styles = StyleSheet.create({
     zIndex: 10,
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: '#e5ecf2',
+    backgroundColor: 'transparent',
   },
   clearButton: {
     width: 26,

--- a/src/ScrollViewListItem.js
+++ b/src/ScrollViewListItem.js
@@ -2,21 +2,21 @@ import React, { memo } from 'react'
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 
 export const ScrollViewListItem = memo(
-  ({ titleHighlighted, titleStart, titleEnd, onPress, numberOfLines = 2 }) => {
+  ({ titleHighlighted, titleStart, titleEnd, style, onPress, numberOfLines = 2 }) => {
     return (
       <TouchableOpacity onPress={onPress}>
         <View style={styles.container}>
           <Text numberOfLines={numberOfLines}>
-            <Text numberOfLines={1} style={{ ...styles.text }}>
+            <Text numberOfLines={1} style={{ ...styles.text, ...style }}>
               {titleStart}
             </Text>
             <Text
               numberOfLines={1}
-              style={{ ...styles.text, fontWeight: 'bold' }}
+              style={{ ...styles.text, ...style, fontWeight: 'bold' }}
             >
               {titleHighlighted}
             </Text>
-            <Text numberOfLines={1} style={{ ...styles.text }}>
+            <Text numberOfLines={1} style={{ ...styles.text, ...style }}>
               {titleEnd}
             </Text>
           </Text>

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -57,6 +57,7 @@ interface AutocompleteDropdownProps {
   ScrollViewComponent?: JSX.Element
   InputComponent?: JSX.Element
   ItemSeparatorComponent?: JSX.Element
+  EmptyResultComponent?: JSX.Element
   emptyResultText?: string
 }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,9 +1,17 @@
 import React, { FC } from 'react'
-import { StyleProp, ViewStyle } from 'react-native'
+import { StyleProp, TextInputProps, TextStyle, ViewStyle } from 'react-native'
 
 export type TAutocompleteDropdownItem = {
   id: string
   title: string | null
+}
+
+export interface AutocompleteDropdownRef {
+  clear: () => void;
+  close: () => void;
+  open: () => Promise<void>;
+  setInputText: (text: string) => void;
+  toggle: () => void;
 }
 
 interface AutocompleteDropdownProps {
@@ -26,21 +34,24 @@ interface AutocompleteDropdownProps {
   closeOnSubmit?: boolean
   clearOnFocus?: boolean
   debounce?: number
+  direction?: 'down' | 'up'
+  position?: 'absolute' | 'relative'
   bottomOffset?: number
-  textInputProps?: object
-  onChangeText?(text: string): any
-  onSelectItem?(item: TAutocompleteDropdownItem): any
+  textInputProps?: TextInputProps
+  onChangeText?: (text: string) => void
+  onSelectItem?: (item: TAutocompleteDropdownItem) => void
   renderItem?: (item: TAutocompleteDropdownItem, searchText: string) => JSX.Element
-  onOpenSuggestionsList?(isOpened: boolean): any
-  onClear?(): any
-  onSubmit?(e: any): any
-  onBlur?(e: any): any
-  onFocus?(e: any): any
-  controller?(controller: any): any
+  onOpenSuggestionsList?: (isOpened: boolean) => void
+  onClear?: () => void
+  onSubmit?: TextInputProps['onSubmitEditing']
+  onBlur?: TextInputProps['onBlur']
+  onFocus?: TextInputProps['onFocus']
+  controller?: (controller: AutocompleteDropdownRef) => void
   containerStyle?: StyleProp<ViewStyle>
   inputContainerStyle?: StyleProp<ViewStyle>
   rightButtonsContainerStyle?: StyleProp<ViewStyle>
   suggestionsListContainerStyle?: StyleProp<ViewStyle>
+  suggestionsListTextStyle?: StyleProp<TextStyle>
   ChevronIconComponent?: JSX.Element
   ClearIconComponent?: JSX.Element
   ScrollViewComponent?: JSX.Element

--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,7 @@ export const AutocompleteDropdown = memo(
     const inputHeight = props.inputHeight ?? moderateScale(40, 0.2)
     const suggestionsListMaxHeight =
       props.suggestionsListMaxHeight ?? moderateScale(200, 0.2)
+    const position = props.position ?? 'absolute'
     const bottomOffset = props.bottomOffset ?? 0
     const ScrollViewComponent = props.ScrollViewComponent ?? ScrollView
     const InputComponent = props.InputComponent ?? TextInput
@@ -165,7 +166,7 @@ export const AutocompleteDropdown = memo(
     const setInputText = (text) => {
       setSearchText(text)
     }
-    
+
     const setItem = (item) => {
       setSelectedItem(item)
     }
@@ -215,6 +216,7 @@ export const AutocompleteDropdown = memo(
           () => (
             <ScrollViewListItem
               {...{ titleHighlighted, titleStart, titleEnd }}
+              style={props.suggestionsListTextStyle}
               onPress={() => _onSelectItem(item)}
             ></ScrollViewListItem>
           ),
@@ -231,14 +233,14 @@ export const AutocompleteDropdown = memo(
       }
 
       const content = []
-      const itemsCount = dataSet.length - 1
+      const itemsCount = dataSet.length
       dataSet.forEach((item, i) => {
         const listItem = renderItem(item, searchText)
         if (listItem) {
           content.push(
             <View key={item.id}>
+              {content.length > 0 && i < itemsCount && ItemSeparatorComponent}
               {listItem}
-              {i < itemsCount && ItemSeparatorComponent}
             </View>
           )
         }
@@ -359,7 +361,8 @@ export const AutocompleteDropdown = memo(
           <View
             style={{
               ...styles.listContainer,
-              [direction === 'down' ? 'top' : 'bottom']: inputHeight + 5,
+              position,
+              ...(position === 'relative' ? { marginTop: 5 } : { [direction === 'down' ? 'top' : 'bottom']: inputHeight + 5 }),
               ...props.suggestionsListContainerStyle,
             }}
           >
@@ -397,6 +400,8 @@ AutocompleteDropdown.propTypes = {
   clearOnFocus: PropTypes.bool,
   resetOnClose: PropTypes.bool,
   debounce: PropTypes.number,
+  direction: PropTypes.oneOf(['down', 'up']),
+  position: PropTypes.oneOf(['absolute', 'relative']),
   suggestionsListMaxHeight: PropTypes.number,
   bottomOffset: PropTypes.number,
   onChangeText: PropTypes.func,
@@ -409,6 +414,7 @@ AutocompleteDropdown.propTypes = {
   containerStyle: PropTypes.object,
   rightButtonsContainerStyle: PropTypes.object,
   suggestionsListContainerStyle: PropTypes.object,
+  suggestionsListTextStyle: PropTypes.object,
   ChevronIconComponent: PropTypes.element,
   ClearIconComponent: PropTypes.element,
   ScrollViewComponent: PropTypes.elementType,
@@ -430,7 +436,6 @@ const styles = ScaledSheet.create({
 
   listContainer: {
     backgroundColor: '#fff',
-    position: 'absolute',
     width: '100%',
     zIndex: 9,
     borderRadius: 5,

--- a/src/index.js
+++ b/src/index.js
@@ -377,7 +377,7 @@ export const AutocompleteDropdown = memo(
                 <View>
                   {scrollContent.length > 0
                     ? scrollContent
-                    : !!searchText && <NothingFound emptyResultText={props.emptyResultText} />}
+                    : !!searchText && (props.EmptyResultComponent ?? <NothingFound emptyResultText={props.emptyResultText} />)}
                 </View>
               }
             </ScrollViewComponent>
@@ -418,6 +418,7 @@ AutocompleteDropdown.propTypes = {
   ChevronIconComponent: PropTypes.element,
   ClearIconComponent: PropTypes.element,
   ScrollViewComponent: PropTypes.elementType,
+  EmptyResultComponent: PropTypes.elementType,
   emptyResultText: PropTypes.string
 }
 


### PR DESCRIPTION
Hi! 👋 
      
Firstly, thanks for your work on this project! 🙂

Today I used [patch-package](https://github.com/ds300/patch-package) to patch `react-native-autocomplete-dropdown@1.1.7` for the project I'm working on.

- Apply styling on text inside the dropdown without redoing all the internal logic to bold the found text part externally.
- Make the dropdown relative without reseting top/bottom every time to have a relative dropdown (prevent playing with `zIndex` which can be horrifying when it comes to have a lists of dropdown that open on bottom and the last one that opens on top).
- Hide the separator when it has only one item as well.
- Make the background of the buttons transparent (it breaks the original border radius or background color change).
- TypeScript typings update.
- Render custom empty result.

<em>This issue body was [partially generated by patch-package](https://github.com/ds300/patch-package/issues/296).</em>
