### PR TITLE
component properties should be of `React.ComponentType` type

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -55,11 +55,11 @@ interface AutocompleteDropdownProps {
   rightButtonsContainerStyle?: StyleProp<ViewStyle>;
   suggestionsListContainerStyle?: StyleProp<ViewStyle>;
   suggestionsListTextStyle?: StyleProp<TextStyle>;
-  ChevronIconComponent?: JSX.Element;
-  ClearIconComponent?: JSX.Element;
-  InputComponent?: JSX.Element;
-  ItemSeparatorComponent?: JSX.Element;
-  EmptyResultComponent?: JSX.Element;
+  ChevronIconComponent?: React.ComponentType;
+  ClearIconComponent?: React.ComponentType;
+  InputComponent?: React.ComponentType;
+  ItemSeparatorComponent?: React.ComponentType;
+  EmptyResultComponent?: React.ComponentType;
   emptyResultText?: string;
   flatListProps?: FlatListProps<any>
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -55,11 +55,11 @@ interface AutocompleteDropdownProps {
   rightButtonsContainerStyle?: StyleProp<ViewStyle>;
   suggestionsListContainerStyle?: StyleProp<ViewStyle>;
   suggestionsListTextStyle?: StyleProp<TextStyle>;
-  ChevronIconComponent?: React.ComponentType;
-  ClearIconComponent?: React.ComponentType;
+  ChevronIconComponent?: JSX.Element;
+  ClearIconComponent?: JSX.Element;
   InputComponent?: React.ComponentType;
-  ItemSeparatorComponent?: React.ComponentType;
-  EmptyResultComponent?: React.ComponentType;
+  ItemSeparatorComponent?: JSX.Element;
+  EmptyResultComponent?: JSX.Element;
   emptyResultText?: string;
   flatListProps?: FlatListProps<any>
 }


### PR DESCRIPTION
component properties should be of `React.ComponentType` type

`JSX.Element` is a rendered instance, ie `<TextInput />`
`React.ComponentType` which is a union of `React.ComponentClass<P, any>` and `React.FunctionComponent<P>` is the component itself - ie the function `TextInput` that returns the JSX