### PR TITLE
fixed onChangeText dependencies

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -215,7 +215,7 @@ export const AutocompleteDropdown = memo(
     const onChangeText = useCallback(text => {
       setSearchText(text)
       debouncedEvent(text)
-    }, [])
+    }, [debouncedEvent])
 
     const onChevronPress = useCallback(() => {
       toggle()
@@ -270,7 +270,7 @@ export const AutocompleteDropdown = memo(
         {/* it's necessary use onLayout here for Androd (bug?) */}
         <View
           ref={containerRef}
-          onLayout={_ => {}}
+          onLayout={_ => { }}
           style={[styles.inputContainerStyle, props.inputContainerStyle]}>
           <InputComponent
             ref={inputRef}


### PR DESCRIPTION
We were having an issue when passing `onChangeText` dinamically. When debugging we found that there was a missing dependency. You can use [this eslint plugin](https://www.npmjs.com/package/eslint-plugin-react-hooks) to stay ahead of future issues like this.