### PR TITLE
Fix error "Cannot read property 'measureInWindow' of null"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -106,7 +106,7 @@ export const AutocompleteDropdown = memo(
 
     const calculateDirection = async () => {
       const [, positionY] = await new Promise(resolve =>
-        containerRef.current.measureInWindow((...rect) => {
+        containerRef.current?.measureInWindow((...rect) => {
           resolve(rect)
         })
       )


### PR DESCRIPTION
It usually sends a warning/error to the console, which is easily fixed with a simple "?"