### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ npm run ios
 | `debounce` 	| wait **ms** before call `onChangeText` 	| number 	| 0 	|
 | `suggestionsListMaxHeight` 	| max height of dropdown 	| number 	| 200 	|
 | `direction` 	| "up" or "down" 	| string 	| down + auto calculate 	|
-| `position` 	| "relative" or "absolute" 	| string 	| relative 	|
+| `position` 	| "relative" or "absolute" 	| string 	| absolute 	|
 | `bottomOffset` 	| for calculate dropdown direction (e.g. tabbar) 	| number 	| 0 	|
 | `onChangeText` 	| event textInput onChangeText 	| function 	|  	|
 | `onSelectItem` 	| event onSelectItem 	| function 	|  	|


### PR DESCRIPTION
Update the default value of position to match the actual behaviour.

The readme states that the default value of position is "relative" but as far as I can see it is, in fact, "absolute",

https://github.com/onmotion/react-native-autocomplete-dropdown/blob/e278c0c7b4e9d6d5e32934f44228a7cfdc6efd4d/src/index.js#L32