### PR TITLE
Update dataSet type to accept null

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -23,7 +23,7 @@ interface AutocompleteDropdownProps {
    *     { id: "3", title: "Gamma" }
    * ]
    */
-  dataSet?: TAutocompleteDropdownItem[]
+  dataSet?: TAutocompleteDropdownItem[] | null
   inputHeight?: number
   suggestionsListMaxHeight?: number
   initialValue?: string | object


### PR DESCRIPTION
![image](https://github.com/onmotion/react-native-autocomplete-dropdown/assets/27006310/5a07342e-3b1f-4b08-b580-b52aa5bd60cb)
fix this error of TS. I guess we want it to be nullable to hide empty list