### PR TITLE
feat: add a prop to trim the seached text by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ yarn ios
 | `closeOnSubmit` 	| whether to close dropdown on submit 	                                                                           | bool 	| false 	                                       |
 | `clearOnFocus` 	| whether to clear typed text on focus 	                                                                          | bool 	| true 	                                        |
 | `ignoreAccents` 	| ignore diacritics 	                                                                                             | bool 	| true 	                                        |
+| `trimSearchText` | trim the searched text                                                                                         | bool 	| true 	                                        |
 | `debounce` 	| wait **ms** before call `onChangeText` 	                                                                        | number 	| 0 	                                           |
 | `suggestionsListMaxHeight` 	| max height of dropdown 	                                                                                        | number 	| 200 	                                         |
 | `direction` 	| "up" or "down" 	                                                                                                | string 	| down + auto calculate 	                       |

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -36,6 +36,7 @@ interface AutocompleteDropdownProps {
   closeOnSubmit?: boolean
   clearOnFocus?: boolean
   ignoreAccents?: boolean
+  trimSearchText?: boolean
   matchFrom?: 'any' | 'start'
   debounce?: number
   direction?: 'down' | 'up'

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,7 @@ export const AutocompleteDropdown = memo(
     const [dataSet, setDataSet] = useState(props.dataSet)
     const clearOnFocus = props.clearOnFocus === false ? false : true
     const ignoreAccents = props.ignoreAccents === false ? false : true
+    const trimSearchText = props.trimSearchText === false ? false : true
     const matchFromStart = props.matchFrom === 'start' ? true : false
     const inputHeight = props.inputHeight ?? moderateScale(40, 0.2)
     const suggestionsListMaxHeight = props.suggestionsListMaxHeight ?? moderateScale(200, 0.2)
@@ -191,7 +192,15 @@ export const AutocompleteDropdown = memo(
         return
       }
 
-      const findWhat = ignoreAccents ? diacriticless(searchText.toLowerCase()) : searchText.toLowerCase()
+      let findWhat = searchText.toLowerCase()
+
+      if (ignoreAccents) {
+          findWhat = diacriticless(findWhat)
+      }
+
+      if (trimSearchText) {
+          findWhat = findWhat.trim()
+      }
 
       const newSet = props.dataSet.filter(item => {
         const findWhere = ignoreAccents ? diacriticless(item.title.toLowerCase()) : item.title.toLowerCase()


### PR DESCRIPTION
Hello,

Could you please consider to add a trimSearchText prop to avoid an empty result when the user add a space to the search text or just click on a suggestion word ?

Thanks for this lib which solved the overlap issue on my Android project