### PR TITLE
Add optional chaining operator

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -117,7 +117,7 @@ export const AutocompleteDropdown = memo(
 
     const _onSelectItem = useCallback(item => {
       setSelectedItem(item)
-      inputRef.current.blur()
+      inputRef.current?.blur()
       setIsOpened(false)
     }, [])
 


### PR DESCRIPTION
While using the library, I ran into an issue. If I pressed the back button of my app or the hardware back button while the dropdown was still open, the dropdown would disappear, but it would still be there as the blur never technically "closed." So if you tapped the places where the dropdown was before disappearing, an error would be thrown saying "TypeError: Cannot read property 'blur' of null". So, I added an optional chaining operator (?.) to the place where .blur() was called just to make sure that inputRef.current isn't null. This fixed the issue!