### PR TITLE
fix #107: add dataSet to the dependencies so that the initialValue works

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -82,7 +82,7 @@ export const AutocompleteDropdown = memo(
       if (dataSetItem) {
         setSelectedItem(dataSetItem)
       }
-    }, [])
+    }, [dataSet])
 
     /** expose controller methods */
     useEffect(() => {


### PR DESCRIPTION
By the time the component mounts, the dataSet is not set and the initialValue is never set due to the missing dependency