### PR TITLE
fix: when the user opens the content dropdown then the user immediately unmounts the component, the content is not reset so an error occurs, because the content is not reset and is on another thread

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -65,6 +65,13 @@ export const AutocompleteDropdown = memo(
       LogBox.ignoreLogs(['VirtualizedLists should never be nested'])
     }, [])
 
+    useEffect(() => {
+      // Do content cleaning when the component is unmounted
+      return () => {
+        setContent(undefined)
+      };
+    }, []);;
+
     /** Set initial value */
     useEffect(() => {
       if (!Array.isArray(dataSet) || selectedItem) {


### PR DESCRIPTION
when the user opens the content dropdown then the user immediately unmounts the component, the content is not reset so an error occurs, because the content is not reset and is on another thread