### PR TITLE
fix: clear dropdown on unmount

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -65,6 +65,13 @@ export const AutocompleteDropdown = memo(
       LogBox.ignoreLogs(['VirtualizedLists should never be nested'])
     }, [])
 
+    useEffect(() => {
+      // Do content cleaning when the component is unmounted
+      return () => {
+        setContent(undefined)
+      };
+    }, []);;
+
     /** Set initial value */
     useEffect(() => {
       if (!Array.isArray(dataSet) || selectedItem) {

--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,7 @@ export const AutocompleteDropdown = memo(
       return () => {
         setContent(undefined)
       };
-    }, []);;
+    }, []);
 
     /** Set initial value */
     useEffect(() => {


### PR DESCRIPTION
#112 
when the user opens the content dropdown then the user immediately unmounts the component, the content is not reset so an error occurs, because the content is not reset and is on another thread