### PR TITLE
Allow usage of dataSet ID as a filter parameter.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -211,12 +211,20 @@ export const AutocompleteDropdown = memo(
       }
 
       const newSet = props.dataSet.filter(item => {
-        const findWhere = ignoreAccents ? diacriticless(item.title.toLowerCase()) : item.title.toLowerCase()
-
-        if (matchFromStart) {
-          return typeof item.title === 'string' && findWhere.startsWith(findWhat)
+        let findWhere = '';
+        if(!isNaN(parseInt(findWhat))) {
+          findWhere = item.id;
         } else {
-          return typeof item.title === 'string' && findWhere.indexOf(findWhat) !== -1
+          findWhere = ignoreAccents ? diacriticless(item.title.toLowerCase()) : item.title.toLowerCase();
+        }
+        if (!isNaN(parseInt(findWhat))) {
+          return (typeof item.id === 'string' && findWhere.indexOf(findWhat) !== -1)
+        } else {
+          if (matchFromStart) {
+            return typeof item.title === 'string' && findWhere.startsWith(findWhat)
+          } else {
+            return typeof item.title === 'string' && findWhere.indexOf(findWhat) !== -1
+          }
         }
       })
 


### PR DESCRIPTION
Hi, I have pushed the code for the scenario where the end user is able to filter the dataset using the ID alongside the title. 
[https://github.com/onmotion/react-native-autocomplete-dropdown/issues/117#issue-2194167242](url)