### PR TITLE
fix: fix type for flatListProps

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -72,6 +72,6 @@ export interface IAutocompleteDropdownProps {
   ItemSeparatorComponent?: React.ComponentType<any> | null
   EmptyResultComponent?: React.ReactElement
   emptyResultText?: string
-  flatListProps?: FlatListProps<any>
+  flatListProps?: Partial<FlatListProps<AutocompleteDropdownItem>>
   ref?: React.LegacyRef<TextInput> | undefined
 }


### PR DESCRIPTION
This PR fixes type for `flatListProps` prop of `IAutocompleteDropdownProps`: it adds `Partial` so that one can pass only some `FlatListProps` props, without the required `data` and `renderItem` (they are passed separately anyway). It also fixes `any` generic type variable to `AutocompleteDropdownItem`.
