### PR TITLE
feat: add enableLoadingIndicator prop for activity indicator control …

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,48 +264,49 @@ yarn android
 
 ## Options
 
-| **Option** 	| **Description** 	                                                                                               | **Type** 	| **Default** 	                                 |
-|---	|-----------------------------------------------------------------------------------------------------------------|---	|-----------------------------------------------|
-| `dataSet` 	| set of list items 	                                                                                             | array 	| null 	                                        |
-| `initialValue` 	| string (**id**) or object that contain **id** 	                                                                 | string \| object 	| null 	                                        |
-| `loading` 	| loading state 	                                                                                                 | bool 	| false 	                                       |
-| `useFilter` 	| whether use local filter by dataSet (useful set to false for remote filtering to prevent rerender twice) 	      | bool 	| true 	                                        |
-| `showClear` 	| show clear button 	                                                                                             | bool 	| true 	                                        |
-| `showChevron` 	| show chevron (open/close) button 	                                                                              | bool 	| true 	                                        |
-| `closeOnBlur` 	| whether to close dropdown on blur 	                                                                             | bool 	| false 	                                       |
-| `closeOnSubmit` 	| whether to close dropdown on submit 	                                                                           | bool 	| false 	                                       |
-| `clearOnFocus` 	| whether to clear typed text on focus 	                                                                          | bool 	| true 	                                        |
-| `caseSensitive`   | whether to perform case-sensitive search 	                                                                          | bool  | false
-| `ignoreAccents` 	| ignore diacritics 	                                                                                             | bool 	| true 	                                        |
-| `trimSearchText` | trim the searched text                                                                                         | bool 	| true 	                                        |
-| `editable` | is textInput editable                                                                                         | bool 	| true 	                                        |
-| `debounce` 	| wait **ms** before call `onChangeText` 	                                                                        | number 	| 0 	                                           |
-| `suggestionsListMaxHeight` 	| max height of dropdown 	                                                                                        | number 	| 200 	                                         |
-| `direction` 	| "up" or "down" 	                                                                                                | string 	| down + auto calculate 	                       |
-| `matchFrom` 	| whether match suggestions from start of titles or anywhere in the title. Possible values are "any" or "start" 	 | string 	| any 	                                         |
-| `bottomOffset` 	| for calculate dropdown direction (e.g. tabbar) 	                                                                | number 	| 0 	                                           |
-| `onChangeText` 	| event textInput onChangeText 	                                                                                  | function 	| 	                                             |
-| `onSelectItem` 	| event onSelectItem 	                                                                                            | function 	| 	                                             |
-| `onOpenSuggestionsList` 	| event onOpenSuggestionsList 	                                                                                   | function 	| 	                                             |
-| `onChevronPress` 	| event onChevronPress 	                                                                                          | function 	| 	                                             |
-| `onClear` 	| event on clear button press 	                                                                                   | function 	| 	                                             |
-| `onSubmit` 	| event on submit KB button press 	                                                                               | function 	| 	                                             |
-| `onBlur` 	| event fired on text input blur 	                                                                                | function 	| 	                                             |
-| `onFocus` 	| event on focus text input 	                                                                                     | function 	| 	                                             |
-| `renderItem` 	| JSX for render item `(item, searchText) => JSX \| null` if return null then the element will not be displayed 	 | function 	| item.title 	                                  |
-| `controller` 	| return reference to module controller with methods **close, open, toggle, clear, setInputText, setItem** 	      | function 	| 	                                             |
-| `containerStyle` 	| 	                                                                                                               | ViewStyle 	| 	                                             |
-| `rightButtonsContainerStyle` 	| 	                                                                                                               | ViewStyle 	| 	                                             |
-| `suggestionsListContainerStyle` 	| 	                                                                                                               | ViewStyle 	| 	                                             |
-| `suggestionsListTextStyle` 	| 	                                                                                                               | TextStyle 	| styles of suggestions list text items 	       |
-| `ChevronIconComponent` 	| 	                                                                                                               | React.Component 	| Feather chevron icon 	                        |
-| `ClearIconComponent` 	| 	                                                                                                               | React.Component 	| Feather x icon 	                              |
-| ~~ScrollViewComponent~~ 	| removed in 2.0.0 based on FlatList 	                                                                            | React.Component name 	| ScrollView that provide suggestions content 	 |
-| `EmptyResultComponent` 	| replace the default `` Component on empty result 	                                                              | React.Component 	| 	                                             |
-| `InputComponent` 	| input element component 	                                                                                       | React.ComponentType 	| TextInput 	                                   |
-| `emptyResultText` 	| replace the default "Nothing found" text on empty result 	                                                      | string 	| "Nothing found" 	                             |
-| `textInputProps` 	| text input props 	                                                                                              | TextInputProps 	| 	                                             |
-| `flatListProps` 	| props for \ component 	                                                                                         | FlatListProps\ 	| 	                                             |
+| Option                         | Description                                                                                                      | Type                | Default                                  |
+|--------------------------------|------------------------------------------------------------------------------------------------------------------|---------------------|------------------------------------------|
+| `dataSet`                      | Set of list items                                                                                                | array               | null                                     |
+| `initialValue`                 | String (**id**) or object that contains **id**                                                                   | string \| object    | null                                     |
+| `loading`                      | Loading state                                                                                                    | bool                | false                                    |
+| `enableLoadingIndicator`       | Whether to show activity indicator on loading                                                                    | bool                | true                                     |
+| `useFilter`                    | Whether to use local filter by dataSet (useful set to false for remote filtering to prevent rerender twice)      | bool                | true                                     |
+| `showClear`                    | Show clear button                                                                                                | bool                | true                                     |
+| `showChevron`                  | Show chevron (open/close) button                                                                                 | bool                | true                                     |
+| `closeOnBlur`                  | Whether to close dropdown on blur                                                                                | bool                | false                                    |
+| `closeOnSubmit`                | Whether to close dropdown on submit                                                                              | bool                | false                                    |
+| `clearOnFocus`                 | Whether to clear typed text on focus                                                                             | bool                | true                                     |
+| `caseSensitive`                | Whether to perform case-sensitive search                                                                         | bool                | false                                    |
+| `ignoreAccents`                | Ignore diacritics                                                                                                | bool                | true                                     |
+| `trimSearchText`               | Trim the searched text                                                                                           | bool                | true                                     |
+| `editable`                     | Is textInput editable                                                                                            | bool                | true                                     |
+| `debounce`                     | Wait **ms** before call `onChangeText`                                                                           | number              | 0                                        |
+| `suggestionsListMaxHeight`     | Max height of dropdown                                                                                           | number              | 200                                      |
+| `direction`                    | "up" or "down"                                                                                                   | string              | down + auto calculate                    |
+| `matchFrom`                    | Whether match suggestions from start of titles or anywhere in the title. Possible values are "any" or "start"    | string              | any                                      |
+| `bottomOffset`                 | For calculate dropdown direction (e.g., tabbar)                                                                  | number              | 0                                        |
+| `onChangeText`                 | Event textInput onChangeText                                                                                     | function            |                                          |
+| `onSelectItem`                 | Event onSelectItem                                                                                               | function            |                                          |
+| `onOpenSuggestionsList`        | Event onOpenSuggestionsList                                                                                      | function            |                                          |
+| `onChevronPress`               | Event onChevronPress                                                                                             | function            |                                          |
+| `onClear`                      | Event on clear button press                                                                                      | function            |                                          |
+| `onSubmit`                     | Event on submit KB button press                                                                                  | function            |                                          |
+| `onBlur`                       | Event fired on text input blur                                                                                   | function            |                                          |
+| `onFocus`                      | Event on focus text input                                                                                        | function            |                                          |
+| `renderItem`                   | JSX for render item `(item, searchText) => JSX \| null` if return null then the element will not be displayed    | function            | item.title                               |
+| `controller`                   | Return reference to module controller with methods **close, open, toggle, clear, setInputText, setItem**         | function            |                                          |
+| `containerStyle`               |                                                                                                                  | ViewStyle           |                                          |
+| `rightButtonsContainerStyle`   |                                                                                                                  | ViewStyle           |                                          |
+| `suggestionsListContainerStyle`|                                                                                                                  | ViewStyle           |                                          |
+| `suggestionsListTextStyle`     |                                                                                                                  | TextStyle           | styles of suggestions list text items    |
+| `ChevronIconComponent`         |                                                                                                                  | React.Component     | Feather chevron icon                     |
+| `ClearIconComponent`           |                                                                                                                  | React.Component     | Feather x icon                           |
+| `EmptyResultComponent`         | Replace the default `Component` on empty result                                                                  | React.Component     |                                          |
+| `InputComponent`               | Input element component                                                                                          | React.ComponentType | TextInput                                |
+| `emptyResultText`              | Replace the default "Nothing found" text on empty result                                                         | string              | "Nothing found"                          |
+| `textInputProps`               | Text input props                                                                                                 | TextInputProps      |                                          |
+| `flatListProps`                | Props for `FlatList` component                                                                                   | FlatListProps       |                                          |
+
 
 ## Usage with a Modal
 

--- a/src/RightButton.tsx
+++ b/src/RightButton.tsx
@@ -58,7 +58,7 @@ export const RightButton: React.FC<RightButtonProps> = memo(
           height: inputHeight,
           ...(buttonsContainerStyle as object),
         }}>
-        {!loading && showClear && (
+        {(!enableLoadingIndicator || !loading) && showClear && (
           <TouchableOpacity onPress={onClearPress} style={styles.clearButton}>
             {ClearIconComponent ?? <XCircle width={18} stroke="#aeb4c6" />}
           </TouchableOpacity>

--- a/src/RightButton.tsx
+++ b/src/RightButton.tsx
@@ -11,6 +11,7 @@ interface RightButtonProps {
   showChevron?: boolean
   showClear?: boolean
   loading?: boolean
+  enableLoadingIndicator?: boolean
   buttonsContainerStyle?: StyleProp<ViewStyle>
   ChevronIconComponent?: React.ReactNode
   ClearIconComponent?: React.ReactNode
@@ -27,6 +28,7 @@ export const RightButton: React.FC<RightButtonProps> = memo(
     showChevron,
     showClear,
     loading,
+    enableLoadingIndicator,
     buttonsContainerStyle,
     ChevronIconComponent,
     ClearIconComponent,
@@ -61,7 +63,7 @@ export const RightButton: React.FC<RightButtonProps> = memo(
             {ClearIconComponent ?? <XCircle width={18} stroke="#aeb4c6" />}
           </TouchableOpacity>
         )}
-        {loading && <ActivityIndicator color="#999" />}
+        {enableLoadingIndicator && loading && <ActivityIndicator color="#999" />}
         {RightIconComponent && (
           <TouchableOpacity onPress={onRightIconComponentPress} style={styles.chevronButton}>
             {RightIconComponent}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -52,6 +52,7 @@ export const AutocompleteDropdown = memo<
       ignoreAccents = true,
       trimSearchText = true,
       editable = true,
+      enableLoadingIndicator = true,
       matchFrom,
       inputHeight = moderateScale(40, 0.2),
       suggestionsListMaxHeight = moderateScale(200, 0.2),
@@ -524,6 +525,7 @@ export const AutocompleteDropdown = memo<
             onChevronPress={onChevronPress}
             showChevron={showChevron ?? true}
             showClear={showClear ?? (!!searchText || !!selectedItem)}
+            enableLoadingIndicator={enableLoadingIndicator}
             loading={loading}
             buttonsContainerStyle={rightButtonsContainerStyle}
             ChevronIconComponent={ChevronIconComponent}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,6 +29,7 @@ export interface IAutocompleteDropdownProps {
   inputHeight?: number
   suggestionsListMaxHeight?: number
   initialValue?: string | { id: string } | AutocompleteDropdownItem
+  enableLoadingIndicator?: boolean
   loading?: boolean
   useFilter?: boolean
   showClear?: boolean


### PR DESCRIPTION
This PR introduces the `enableLoadingIndicator` prop to provide better control over the visibility of the activity indicator during loading states.

The current implementation has a limitation where the `RightIconComponent` may visually dangle or shift improperly when transitioning from a loading (true) to not loading (false) state, particularly when using a custom right button with showClear set to false.

The issue arises due to the conditional rendering of the clear button component, which does not account for cases where the loading indicator might be undesirable or visually intrusive. Here’s the problematic segment:

```js
{!loading && showClear && (
  <TouchableOpacity onPress={onClearPress} style={styles.clearButton}>
    {ClearIconComponent ?? <XCircle width={18} stroke="#aeb4c6" />}
  </TouchableOpacity>
)}
```

With the addition of the `enableLoadingIndicator` boolean, users will have the flexibility to enable or disable the loading indicator based on their specific needs, thus preventing the unwanted dangling effect of the RightIconComponent during the load transition.

Attached is a video demonstrating the issue with:
- `showClear = false`
- `RightIconComponent = <CustomComponent>`


https://github.com/user-attachments/assets/ef9ee2f9-e2bb-4baa-92e2-67127d65c2be

