### PR TITLE
fix: explicit passing Dropdown props to prevent maximum update depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ No additional steps are necessary
 
 ## Usage
 
-Wrap your root component in `AutocompleteDropdownContextProvider` from `react-native-autocomplete-dropdown` as you can see in [example](https://github.com/onmotion/react-native-autocomplete-dropdown/blob/main/example/App.js)
+Wrap your root component in `AutocompleteDropdownContextProvider` from `react-native-autocomplete-dropdown` as you can see in [example](https://github.com/onmotion/react-native-autocomplete-dropdown/blob/main/example/App.tsx)
 
 ```js
 <AutocompleteDropdownContextProvider>

--- a/README^2.md
+++ b/README^2.md
@@ -208,7 +208,7 @@ export const RemoteDataSetExample2 = memo(() => {
 
 ```
 
-More examples see at <https://github.com/onmotion/react-native-autocomplete-dropdown/tree/main/example>
+More examples see at <https://github.com/onmotion/react-native-autocomplete-dropdown/tree/2.1.1/example>
 
 Run
 

--- a/README^3.md
+++ b/README^3.md
@@ -77,7 +77,7 @@ No additional steps are necessary
 
 ## Usage
 
-Wrap your root component in `AutocompleteDropdownContextProvider` from `react-native-autocomplete-dropdown` as you can see in [example](https://github.com/onmotion/react-native-autocomplete-dropdown/blob/main/example/App.js)
+Wrap your root component in `AutocompleteDropdownContextProvider` from `react-native-autocomplete-dropdown` as you can see in [example](https://github.com/onmotion/react-native-autocomplete-dropdown/blob/3.1.5/example/App.tsx)
 
 ```js
 <AutocompleteDropdownContextProvider>
@@ -245,7 +245,7 @@ export const RemoteDataSetExample2 = memo(() => {
 
 ```
 
-More examples see at <https://github.com/onmotion/react-native-autocomplete-dropdown/tree/main/example>
+More examples see at <https://github.com/onmotion/react-native-autocomplete-dropdown/tree/3.1.5/example>
 
 ## Playground
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -475,6 +475,7 @@ export const AutocompleteDropdown = memo<
       } else {
         setContent(undefined)
       }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [
       ListEmptyComponent,
       activeInputContainerRef,
@@ -482,7 +483,9 @@ export const AutocompleteDropdown = memo<
       direction,
       inputHeight,
       isOpened,
-      props,
+      props.suggestionsListContainerStyle,
+      props.flatListProps,
+      props.ItemSeparatorComponent,
       renderItem,
       setContent,
       suggestionsListMaxHeight,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -461,21 +461,20 @@ export const AutocompleteDropdown = memo<
 
         setContent(
           <Dropdown
-            {...{
-              ...props,
-              direction,
-              inputHeight,
-              dataSet,
-              suggestionsListMaxHeight,
-              renderItem,
-              ListEmptyComponent,
-            }}
+            direction={direction}
+            inputHeight={inputHeight}
+            dataSet={dataSet}
+            suggestionsListMaxHeight={suggestionsListMaxHeight}
+            renderItem={renderItem}
+            ListEmptyComponent={ListEmptyComponent}
+            suggestionsListContainerStyle={props.suggestionsListContainerStyle}
+            flatListProps={props.flatListProps}
+            ItemSeparatorComponent={props.ItemSeparatorComponent}
           />,
         )
       } else {
         setContent(undefined)
       }
-      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [
       ListEmptyComponent,
       activeInputContainerRef,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -461,15 +461,15 @@ export const AutocompleteDropdown = memo<
 
         setContent(
           <Dropdown
-            direction={direction}
-            inputHeight={inputHeight}
             dataSet={dataSet}
+            direction={direction}
+            flatListProps={props.flatListProps}
+            inputHeight={inputHeight}
+            suggestionsListContainerStyle={props.suggestionsListContainerStyle}
             suggestionsListMaxHeight={suggestionsListMaxHeight}
             renderItem={renderItem}
-            ListEmptyComponent={ListEmptyComponent}
-            suggestionsListContainerStyle={props.suggestionsListContainerStyle}
-            flatListProps={props.flatListProps}
             ItemSeparatorComponent={props.ItemSeparatorComponent}
+            ListEmptyComponent={ListEmptyComponent}
           />,
         )
       } else {


### PR DESCRIPTION
# Description
This PR fixes an issue in the `AutocompleteDropdown` component that caused a "Maximum update depth exceeded" error when passing a `ref` prop starting RN 0.78 (maybe linked to the [ref as props](https://react.dev/blog/2024/12/05/react-19#ref-as-a-prop) React v19 update?).

NB: I use this`ref` prop to control some part of the underlying `TextInput` component.


# Repro
This [repo](https://github.com/robinshin/react-native-autocomplete-dropdown-maximum-update-depth-issue-repro) contains 3 commits:
1. A raw new RN project [commit](https://github.com/robinshin/react-native-autocomplete-dropdown-maximum-update-depth-issue-repro/commit/0499b3a42c1af49b035ad0afd428dd1ab43d1656)
2. Setup `react-native-autocomplete-dropdown` + copy LocalDatasetExample from the `example/` folder [commit](https://github.com/robinshin/react-native-autocomplete-dropdown-maximum-update-depth-issue-repro/commit/17461c8d9d852458ba5b1c54f88c6282ee7d7cc9)
3. Adding a ref to the `AutocompleteDropdown` component [commit](https://github.com/robinshin/react-native-autocomplete-dropdown-maximum-update-depth-issue-repro/commit/185dc011934f84ecfaa13b80f4576e074258a7dd) <- this commit provokes the error when the dropdown displays

<img width="1512" alt="Capture d’écran 2025-03-20 à 12 29 17" src="https://github.com/user-attachments/assets/46a31780-0c38-4e0e-a4fc-c16045fbba69" />


# Changes made
- **Explicit props passing to the `Dropdown` component**
Instead of spreading the entire props object into `Dropdown`, the code now explicitly passes only the necessary properties.

- **Stable dependencies in `useEffect`**
Modified the `useEffect` that sets the Dropdown's content so that only the necessary props are passed down. This helps ensure that unstable object references (including the ref now passed as a prop) do not trigger repeated re-renders.

- **Update README.md broken links**
Just fixes some broken documentation links