### PR TITLE
feat: make context provider compatible more modals (ie gluestack)

### DIFF
--- a/src/AutocompleteDropdownContext.tsx
+++ b/src/AutocompleteDropdownContext.tsx
@@ -138,13 +138,13 @@ export const AutocompleteDropdownContextProvider: FC<IAutocompleteDropdownContex
       }}>
       <View
         ref={wrapperRef}
-        style={styles.clickOutsideHandlerArea}
+        style={StyleSheet.absoluteFill}
         onTouchEnd={() => {
           activeControllerRef.current?.close()
           activeControllerRef.current?.blur()
         }}>
-        {children}
       </View>
+      {children}
       {!!content && show && (
         <View
           onLayout={onLayout}
@@ -161,9 +161,6 @@ export const AutocompleteDropdownContextProvider: FC<IAutocompleteDropdownContex
 }
 
 const styles = StyleSheet.create({
-  clickOutsideHandlerArea: {
-    flex: 1,
-  },
   wrapper: {
     position: 'absolute',
   },


### PR DESCRIPTION
This change moves the children out of the backdrop view and makes the backdrop not contribute to layout.

Libraries like [Gluestack](https://gluestack.io/ui/docs/components/modal) would break if the context provider altered the children's parent/layout.
```jsx
<Modal isOpen={open} onClose={requestClose} size="md">
	<AutocompleteDropdownContextProvider> {/* < --- this will break the modal if not updated  */}
		<ModalBackdrop />
		<ModalContent>
			<ModalHeader>
				<Heading size="lg">Modal Header</Heading>
				<ModalCloseButton>
					<Icon as={CloseIcon} />
				</ModalCloseButton>
			</ModalHeader>
			<ModalBody>
				<AutocompleteDropdown .../>
...
```